### PR TITLE
add method to application_controller in order to change path sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,12 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [:username, :photo, :is_vendor])
   end
 
+  protected
+
+  # def after_sign_in_path_for(resource)
+  #   current_user_path
+  # end
+
   private
 
   def skip_pundit?


### PR DESCRIPTION
J'ai rajouté une méthode dans le application controller pour rediriger vers la bonne page lors d'un sign up après une commande, le problème c'est que ça ne sauvegarde pas pour l'instant la commande, donc j'ai mis en commentaire pour l'instant